### PR TITLE
Local setup to run benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,18 @@ benchmark:
 
 proto:
 	protoc --go_out=./messages/model ./messages/proto/payments.proto
+
+stop-containers:
+	docker compose -f payment-processors/docker-compose.yml down
+	docker compose down
+
+start-payment-processors:
+	docker compose -f payment-processors/docker-compose.yml up -d
+
+start-backend:
+	docker compose up
+
+run-k6-tests:
+	k6 run tests/rinha.js
+
+test: stop-containers start-payment-processors start-backend run-k6-tests

--- a/payment-processors/docker-compose.yml
+++ b/payment-processors/docker-compose.yml
@@ -1,0 +1,74 @@
+x-service-templates:
+  payment-processor: &payment-processor
+    image: zanfranceschi/payment-processor:amd64-20250707101540
+    networks:
+      - payment-processor
+    deploy:
+      resources:
+        limits:
+          cpus: "1.5"
+          memory: "100MB"
+  
+  payment-processor-db: &payment-processor-db
+    image: postgres:17-alpine
+    networks:
+      - payment-processor
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=rinha
+    deploy:
+      resources:
+        limits:
+          cpus: "1.5"
+          memory: "250MB"
+
+services:
+  payment-processor-1:
+    <<: *payment-processor
+    container_name: payment-processor-default
+    hostname: payment-processor-default
+    environment:
+      - TRANSACTION_FEE=0.05
+      - RATE_LIMIT_SECONDS=5
+      - INITIAL_TOKEN=123
+      - DB_CONNECTION_STRING=Host=payment-processor-default-db;Port=5432;Database=rinha;Username=postgres;Password=postgres;Minimum Pool Size=15;Maximum Pool Size=20;Connection Pruning Interval=3
+    ports:
+      - 8001:8080
+    depends_on:
+      - payment-processor-db-1
+    
+  payment-processor-db-1:
+    <<: *payment-processor-db
+    container_name: payment-processor-default-db
+    hostname: payment-processor-default-db
+    ports:
+      - 54321:5432
+
+  payment-processor-2:
+    <<: *payment-processor
+    container_name: payment-processor-fallback
+    hostname: payment-processor-fallback
+    environment:
+      - TRANSACTION_FEE=0.15
+      - RATE_LIMIT_SECONDS=5
+      - INITIAL_TOKEN=123
+      - DB_CONNECTION_STRING=Host=payment-processor-fallback-db;Port=5432;Database=rinha;Username=postgres;Password=postgres;Minimum Pool Size=15;Maximum Pool Size=20;Connection Pruning Interval=3
+    ports:
+      - 8002:8080
+    depends_on:
+      - payment-processor-db-2
+  
+  payment-processor-db-2:
+    <<: *payment-processor-db
+    container_name: payment-processor-fallback-db
+    hostname: payment-processor-fallback-db
+    ports:
+      - 54322:5432
+
+networks:
+  payment-processor:
+    name: payment-processor
+    driver: bridge

--- a/payment-processors/init.sql
+++ b/payment-processors/init.sql
@@ -1,0 +1,8 @@
+
+CREATE UNLOGGED TABLE payments (
+    correlationId UUID PRIMARY KEY,
+    amount DECIMAL NOT NULL,
+    requested_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX payments_requested_at ON payments (requested_at);

--- a/tests/requests.js
+++ b/tests/requests.js
@@ -1,0 +1,131 @@
+import { Httpx } from 'https://jslib.k6.io/httpx/0.1.0/index.js';
+import exec from 'k6/execution';
+
+const initialToken = '123';
+export const token = __ENV.TOKEN ?? initialToken;
+
+const paymentProcessorDefaultHttp = new Httpx({
+    baseURL: 'http://localhost:8001',
+    headers: {
+        'Content-Type': 'application/json',
+        'X-Rinha-Token': token
+    },
+    timeout: 1500,
+});
+
+const paymentProcessorFallbacktHttp = new Httpx({
+    baseURL: 'http://localhost:8002',
+    headers: {
+        'Content-Type': 'application/json',
+        'X-Rinha-Token': token
+    },
+    timeout: 1500,
+});
+
+const backendHttp = new Httpx({
+    baseURL: "http://localhost:9999",
+    //baseURL: "http://localhost:5123",
+    headers: {
+        "Content-Type": "application/json",
+    },
+    timeout: 1500,
+});
+
+const paymentProcessorHttp = {
+    "default": paymentProcessorDefaultHttp,
+    "fallback": paymentProcessorFallbacktHttp,
+};
+
+export async function setPPToken(service, token) {
+
+    const httpClient = paymentProcessorHttp[service];
+    const params = { headers: { 'X-Rinha-Token': initialToken } };
+
+    const payload = JSON.stringify({
+        token: token
+    });
+
+    const response = await httpClient.asyncPut('/admin/configurations/token', payload, params);
+
+    if (response.status != 204) {
+        exec.test.abort(`Erro ao definir token para ${service} (HTTP ${response.status}).`);
+    }
+}
+
+export async function setPPDelay(service, ms) {
+
+    const httpClient = paymentProcessorHttp[service];
+
+    const payload = JSON.stringify({
+        delay: ms
+    });
+
+    const response = await httpClient.asyncPut('/admin/configurations/delay', payload);
+
+    if (response.status != 200) {
+        exec.test.abort(`Erro ao definir delay para ${service} (HTTP ${response.status}).`);
+    }
+}
+
+export async function setPPFailure(service, failure) {
+
+    const httpClient = paymentProcessorHttp[service];
+
+    const payload = JSON.stringify({
+        failure: failure
+    });
+
+    const response = await httpClient.asyncPut('/admin/configurations/failure', payload);
+
+    if (response.status != 200) {
+        exec.test.abort(`Erro ao definir failure para ${service} (HTTP ${response.status}).`);
+    }
+}
+
+export async function resetPPDatabase(service) {
+
+    const httpClient = paymentProcessorHttp[service];
+    const response = await httpClient.asyncPost('/admin/purge-payments');
+
+    if (response.status != 200) {
+        exec.test.abort(`Erro ao resetar database para ${service} (HTTP ${response.status}).`);
+    }
+}
+
+export async function getPPPaymentsSummary(service, from, to) {
+
+    const httpClient = paymentProcessorHttp[service];
+    const response = await httpClient.asyncGet(`/admin/payments-summary?from=${from}&to=${to}`);
+
+    if (response.status != 200) {
+        exec.test.abort(`Erro ao obter admin payments summary para ${service} (HTTP ${response.status}).`);
+    }
+
+    return JSON.parse(response.body);
+}
+
+export async function resetBackendDatabase() {
+
+    try {
+        await backendHttp.asyncPost('/purge-payments');
+    } catch (error) {
+        console.info("Seu backend provavelmente não possui um endpoint para resetar o banco. Isso não é um problem.", error.message);
+    }
+}
+
+export async function getBackendPaymentsSummary(from, to) {
+
+    const response = await backendHttp.asyncGet(`/payments-summary?from=${from}&to=${to}`);
+
+    if (response.status != 200) {
+        exec.test.abort(`Erro ao obter payments summary do backend (HTTP ${response.status}).`);
+    }
+
+    return JSON.parse(response.body);
+}
+
+export async function requestBackendPayment(payload) {
+
+    const response = await backendHttp.asyncPost('/payments', JSON.stringify(payload));
+    return response;
+}

--- a/tests/rinha.js
+++ b/tests/rinha.js
@@ -1,0 +1,297 @@
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.1.0/index.js';
+import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
+import { sleep } from "k6";
+import exec from "k6/execution";
+import { Counter } from "k6/metrics";
+import {
+    token,
+    setPPToken,
+    setPPDelay,
+    setPPFailure,
+    resetPPDatabase,
+    getPPPaymentsSummary,
+    resetBackendDatabase,
+    getBackendPaymentsSummary,
+    requestBackendPayment
+} from "./requests.js";
+
+export const options = {
+    summaryTrendStats: [
+        "p(99)",
+        "count",
+    ],
+    thresholds: {
+        //http_req_failed: [{ threshold: "rate < 0.01", abortOnFail: false }],
+        //payments_inconsistency: ["count == 0"]
+        //http_req_duration: ['p(99) < 50'],
+        //payments_count: ['count > 3500'],
+    },
+    scenarios: {
+        payments: {
+            exec: "payments",
+            executor: "ramping-vus",
+            startVUs: 1,
+            gracefulRampDown: "0s",
+            stages: [{ target: __ENV.MAX_REQUESTS ?? 500, duration: "60s" }],
+        },
+        payments_consistency: {
+            exec: "checkPayments",
+            executor: "constant-vus",
+            //startTime: "5s",
+            duration: "60s",
+            vus: "1",
+        },
+        stage_00: {
+            exec: "define_stage",
+            startTime: "1s",
+            executor: "constant-vus",
+            vus: 1,
+            duration: "1s",
+            tags: {
+                defaultDelay: "0",
+                defaultFailure: "false",
+                fallbackDelay: "0",
+                fallbackFailure: "false",
+            },
+        },
+        stage_01: {
+            exec: "define_stage",
+            startTime: "10s",
+            executor: "constant-vus",
+            vus: 1,
+            duration: "1s",
+            tags: {
+                defaultDelay: "100",
+                defaultFailure: "false",
+                fallbackDelay: "0",
+                fallbackFailure: "false",
+            },
+        },
+        stage_02: {
+            exec: "define_stage",
+            startTime: "20s",
+            executor: "constant-vus",
+            vus: 1,
+            duration: "1s",
+            tags: {
+                defaultDelay: "100",
+                defaultFailure: "true",
+                fallbackDelay: "0",
+                fallbackFailure: "false",
+            },
+        },
+        stage_03: {
+            exec: "define_stage",
+            startTime: "30s",
+            executor: "constant-vus",
+            vus: 1,
+            duration: "1s",
+            tags: {
+                defaultDelay: "2000",
+                defaultFailure: "true",
+                fallbackDelay: "1000",
+                fallbackFailure: "true",
+            },
+        },
+        stage_04: {
+            exec: "define_stage",
+            startTime: "40s",
+            executor: "constant-vus",
+            vus: 1,
+            duration: "1s",
+            tags: {
+                defaultDelay: "20",
+                defaultFailure: "false",
+                fallbackDelay: "20",
+                fallbackFailure: "false",
+            },
+        },
+        stage_05: {
+            exec: "define_stage",
+            startTime: "50s",
+            executor: "constant-vus",
+            vus: 1,
+            duration: "1s",
+            tags: {
+                defaultDelay: "0",
+                defaultFailure: "false",
+                fallbackDelay: "5000",
+                fallbackFailure: "false",
+            },
+        },
+    },
+};
+
+const transactionsSuccessCounter = new Counter("transactions_success");
+const transactionsFailureCounter = new Counter("transactions_failure");
+const totalTransactionsAmountCounter = new Counter("total_transactions_amount");
+const balanceInconsistencyCounter = new Counter("balance_inconsistency_amount");
+
+const defaultTotalAmountCounter = new Counter("default_total_amount");
+const defaultTotalRequestsCounter = new Counter("default_total_requests");
+const fallbackTotalAmountCounter = new Counter("fallback_total_amount");
+const fallbackTotalRequestsCounter = new Counter("fallback_total_requests");
+
+const defaultTotalFeeCounter = new Counter("default_total_fee");
+const fallbackTotalFeeCounter = new Counter("fallback_total_fee");
+
+export async function setup() {
+    await resetPPDatabase("default");
+    await resetPPDatabase("fallback");
+    await resetBackendDatabase();
+    await setPPToken("default", token);
+    await setPPToken("fallback", token);
+}
+
+export async function teardown() {
+
+    const from = "2000-01-01T00:00:00";
+    const to = "2900-01-01T00:00:00";
+    const defaultResponse = await getPPPaymentsSummary("default", from, to);
+    const fallbackResponse = await getPPPaymentsSummary("fallback", from, to);
+    const backendPaymentsSummary = await getBackendPaymentsSummary(from, to);
+
+    totalTransactionsAmountCounter.add(
+        backendPaymentsSummary.default.totalAmount +
+        backendPaymentsSummary.fallback.totalAmount);
+
+    defaultTotalAmountCounter.add(backendPaymentsSummary.default.totalAmount);
+    defaultTotalRequestsCounter.add(backendPaymentsSummary.default.totalRequests);
+    fallbackTotalAmountCounter.add(backendPaymentsSummary.fallback.totalAmount);
+    fallbackTotalRequestsCounter.add(backendPaymentsSummary.fallback.totalRequests);
+
+    const defaultTotalFee = defaultResponse.feePerTransaction * backendPaymentsSummary.default.totalAmount;
+    const fallbackTotalFee = fallbackResponse.feePerTransaction * backendPaymentsSummary.fallback.totalAmount;
+
+    defaultTotalFeeCounter.add(defaultTotalFee);
+    fallbackTotalFeeCounter.add(fallbackTotalFee);
+}
+
+const paymentRequestFixedAmount = 19.90;
+
+export async function payments() {
+
+    const payload = {
+        correlationId: uuidv4(),
+        amount: paymentRequestFixedAmount
+    };
+
+    const response = await requestBackendPayment(payload);
+
+    if ([200, 201, 202, 204].includes(response.status)) {
+        transactionsSuccessCounter.add(1);
+        transactionsFailureCounter.add(0);
+    } else {
+        transactionsSuccessCounter.add(0);
+        transactionsFailureCounter.add(1);
+    }
+
+    sleep(1);
+}
+
+export async function checkPayments() {
+
+    const now = new Date();
+
+    const from = new Date(now - 1000 * 10).toISOString();
+    const to = new Date(now - 100).toISOString();
+
+    const defaultAdminPaymentsSummary = await getPPPaymentsSummary(
+        "default",
+        from,
+        to,
+    );
+    const fallbackAdminPaymentsSummary = await getPPPaymentsSummary(
+        "fallback",
+        from,
+        to,
+    );
+    const backendPaymentsSummary = await getBackendPaymentsSummary(from, to);
+
+    const inconsistencies =
+        Math.abs(
+            backendPaymentsSummary.default.totalAmount -
+            defaultAdminPaymentsSummary.totalAmount,
+        ) +
+        Math.abs(
+            backendPaymentsSummary.fallback.totalAmount -
+            fallbackAdminPaymentsSummary.totalAmount,
+        );
+
+    balanceInconsistencyCounter.add(inconsistencies);
+
+    sleep(10);
+}
+
+export async function define_stage() {
+    const defaultMs = parseInt(exec.vu.metrics.tags["defaultDelay"]);
+    const fallbackMs = parseInt(exec.vu.metrics.tags["fallbackDelay"]);
+    const defaultFailure = exec.vu.metrics.tags["defaultFailure"] === "true";
+    const fallbackFailure = exec.vu.metrics.tags["fallbackFailure"] === "true";
+
+    await setPPDelay("default", defaultMs);
+    await setPPDelay("fallback", fallbackMs);
+
+    await setPPFailure("default", defaultFailure);
+    await setPPFailure("fallback", fallbackFailure);
+
+    sleep(1);
+}
+
+export function handleSummary(data) {
+
+    const expected_total_amount = data.metrics.transactions_success.values.count * paymentRequestFixedAmount;
+    const actual_total_amount = data.metrics.total_transactions_amount.values.count;
+    const difference_total_amount = expected_total_amount - actual_total_amount;
+
+    const default_total_fee = data.metrics.default_total_fee.values.count;
+    const fallback_total_fee = data.metrics.fallback_total_fee.values.count;
+    const total_fee = default_total_fee + fallback_total_fee;
+
+    const p_99 = data.metrics["http_req_duration{expected_response:true}"].values["p(99)"];
+    const p_99_bonus = Math.max((11 - p_99) * 0.02, 0);
+    const contains_inconsistencies = difference_total_amount != 0 || data.metrics.balance_inconsistency_amount.values.count != 0;
+    const inconsistencies_fine = contains_inconsistencies ? 0.35 : 0;
+
+    const liquid_partial_amount = (actual_total_amount - total_fee);
+
+    const liquid_amount = liquid_partial_amount
+        + (liquid_partial_amount * p_99_bonus)
+        - (liquid_partial_amount * inconsistencies_fine);
+
+    const custom_data = {
+        liquid_amount: Math.round(liquid_amount, 2),
+        points: "The 'liquid_amount' is the total points/profit you got.",
+        actual_total_amount: actual_total_amount,
+        expected_total_amount: expected_total_amount,
+        p_99: Math.round(p_99, 2),
+        p_99_bonus: p_99_bonus,
+        inconsistencies_fine: inconsistencies_fine,
+        fine_amount: Math.round(liquid_partial_amount * inconsistencies_fine, 2),
+
+        balance_inconsistency_amount: Math.round(data.metrics.balance_inconsistency_amount.values.count, 2),
+
+        transactions_success: data.metrics.transactions_success.values.count,
+        transactions_failure: data.metrics.transactions_failure.values.count,
+
+        default_total_amount: data.metrics.default_total_amount.values.count,
+        default_total_requests: data.metrics.default_total_requests.values.count,
+        fallback_total_amount: data.metrics.fallback_total_amount.values.count,
+        fallback_total_requests: data.metrics.fallback_total_requests.values.count,
+        default_total_fee: data.metrics.default_total_fee.values.count,
+        fallback_total_fee: data.metrics.fallback_total_fee.values.count,
+    };
+
+    const result = {
+        stdout: textSummary(data),
+    };
+
+    const participant = __ENV.PARTICIPANT;
+
+    if (participant != null) {
+        const summaryJsonFileName = `../participantes/${participant}/partial-result.json`
+        result[summaryJsonFileName] = JSON.stringify(custom_data);
+    }
+
+    return result;
+}


### PR DESCRIPTION
Hey @agelito,

This PR will allow us to run the benchmark locally, there is a guide for the setup here: https://github.com/zanfranceschi/rinha-de-backend-2025/blob/main/rinha-test/MINIGUIA.md

It uses K6 to run the tests and it is the only dependency that need to be installed to run ([install](https://grafana.com/docs/k6/latest/set-up/install-k6/)).

It won't run right now, because it needs the `/payments-summary` and `/purge-payments` endpoints implemented.

It can be run:

```bash
# directly via the terminal
k6 run tests/rinha.js

# only test command via make command
make run-k6-tests

# with containerized  backend via make command
make test
```
