### PR TITLE
feat: wait for payment processing confirmation

### DIFF
--- a/messages/subjects/subjects.go
+++ b/messages/subjects/subjects.go
@@ -1,5 +1,12 @@
 package subjects
 
+import "fmt"
+
 const (
-	SubjectPaymentsProcess = "payments.process"
+	SubjectPaymentsProcess    = "payments.process"
+	subjectPaymentsConfirmFmt = "payments.confirm.%s"
 )
+
+func NewPaymentsConfirmChannel(correlationId string) string {
+	return fmt.Sprintf(subjectPaymentsConfirmFmt, correlationId)
+}

--- a/payment-worker/main.go
+++ b/payment-worker/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	defer nc.Close()
 
-	handler := handler.NewPaymentsHandler()
+	handler := handler.NewPaymentsHandler(nc)
 	service := service.NewNatsService(nc, handler)
 
 	service.Run()

--- a/payment-worker/pkg/handler/payments.go
+++ b/payment-worker/pkg/handler/payments.go
@@ -1,14 +1,27 @@
 package handler
 
-import "fmt"
+import (
+	"fmt"
 
-type PaymentsHandler struct{}
+	"github.com/agelito/rinha-de-backend-2025/messages/subjects"
+	"github.com/nats-io/nats.go"
+)
 
-func NewPaymentsHandler() *PaymentsHandler {
-	return &PaymentsHandler{}
+type PaymentsHandler struct {
+	nc *nats.Conn
+}
+
+func NewPaymentsHandler(nc *nats.Conn) *PaymentsHandler {
+	return &PaymentsHandler{nc: nc}
 }
 
 func (h *PaymentsHandler) ProcessPayment(correlationId string, amount string) error {
 	fmt.Printf("payment: correlationId: %v, amount: %v\n", correlationId, amount)
+
+	confirmSubject := subjects.NewPaymentsConfirmChannel(correlationId)
+	if err := h.nc.Publish(confirmSubject, []byte{}); err != nil {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
I've added logic to wait for the payment processing to be confirmed before responding in the `POST /payments` endpoint. For now the `payment-worker` handler is responsible for sending this processing confirmation but we may want to send it from the service persisting the record in the future.

The processing confirmation messages is published to the `payments.confirm.{correlationId}` subject allowing other services to also subscribe if necessary in the future (perhaps we want to log each successful payment, in that case we could subscribe to `payments.confirm.*`).

The confirmation messages doesn't send any data currently, we can evaluate adding some sort of result (success/failure) or other data if necessary in the future.